### PR TITLE
Multiprocessing review

### DIFF
--- a/pe.audio.sys/share/scripts/lcd/lcd_daemon.py
+++ b/pe.audio.sys/share/scripts/lcd/lcd_daemon.py
@@ -28,7 +28,7 @@ import lcd_client
 import os
 import yaml
 import json
-import multiprocessing
+import threading
 
 UHOME = os.path.expanduser("~")
 
@@ -360,5 +360,5 @@ if __name__ == "__main__":
                       path=WATCHED_DIR,
                       recursive=False)
     observer.start()
-    obsloop = multiprocessing.Process( target=observer.join() )
+    obsloop = threading.Thread( target=observer.join() )
     obsloop.start()

--- a/pe.audio.sys/share/scripts/loudness_monitor/loudness_monitor_daemon.py
+++ b/pe.audio.sys/share/scripts/loudness_monitor/loudness_monitor_daemon.py
@@ -38,7 +38,7 @@ import sounddevice as sd
 # Will reset the (I) measurement when input changes
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
-import multiprocessing
+import threading
 
 UHOME           = os.path.expanduser("~")
 MAINFOLDER      = f'{UHOME}/pe.audio.sys'
@@ -217,8 +217,8 @@ if __name__ == '__main__':
 
     # Threading to control this script (currently only the 'reset' flag)
     control_fifo_prepare(args.control_fifo)
-    control = multiprocessing.Process( target=control_fifo_read_loop,
-                                       args=(args.control_fifo,) )
+    control = threading.Thread( target=control_fifo_read_loop,
+                                args=(args.control_fifo,) )
     control.start()
 
     # Starts an Observer watchdog for file changes
@@ -230,7 +230,7 @@ if __name__ == '__main__':
     observer = Observer()
     observer.schedule( event_handler=My_files_event_handler(),
                        path=MAINFOLDER, recursive=False )
-    obsthread = multiprocessing.Process( target=observer.start() )
+    obsthread = threading.Thread( target=observer.start() )
     obsthread.start()
 
     # Internal FIFO queue

--- a/pe.audio.sys/share/scripts/spotify_monitor/spotify_monitor_daemon_v2.py
+++ b/pe.audio.sys/share/scripts/spotify_monitor/spotify_monitor_daemon_v2.py
@@ -39,7 +39,7 @@ import os
 import subprocess as sp
 import json
 import time
-import multiprocessing
+import threading
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 
@@ -124,5 +124,5 @@ if __name__ == "__main__":
     observer.schedule(event_handler=Changed_files_handler(),
                       path=MAINFOLDER, recursive=False)
     observer.start()
-    obsloop = multiprocessing.Process( target=observer.join() )
+    obsloop = threading.Thread( target=observer.join() )
     obsloop.start()

--- a/pe.audio.sys/share/services/players.py
+++ b/pe.audio.sys/share/services/players.py
@@ -31,7 +31,7 @@
 
 import os
 import subprocess as sp
-import multiprocessing
+import threading
 import yaml
 from time import sleep
 import json
@@ -164,7 +164,7 @@ def init():
             sleep(timer)
     # Loop storing metadata
     meta_timer = 2
-    meta_loop = multiprocessing.Process( target=store_meta, args=(meta_timer,) )
+    meta_loop = threading.Thread( target=store_meta, args=(meta_timer,) )
     meta_loop.start()
     # Flush state file:
     with open( f'{MAINFOLDER}/.player_state', 'w') as f:

--- a/pe.audio.sys/share/services/preamp_mod/bfeq2png.py
+++ b/pe.audio.sys/share/services/preamp_mod/bfeq2png.py
@@ -24,7 +24,14 @@ import sys
 import os
 from socket import socket
 import numpy as np
-from matplotlib import pyplot as plt
+import matplotlib
+# (i) Agg is a SAFE backend to avoid "tkinter.TclError: couldn't connect to display"
+#     under certain circumstances.
+#     https://matplotlib.org/faq/usage_faq.html#what-is-a-backend
+#     Comment out this line if you want to test plotting under your standard backend
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
 
 UHOME       = os.path.expanduser("~")
 RGBweb      = (.15, .15, .15)   # same as index.html background-color: rgb(38, 38, 38);
@@ -94,7 +101,7 @@ def do_graph(freqs, magdB):
     plt.savefig( fpng, facecolor=RGBweb )
     if verbose:
         print( f'(bfeq2png) saved: \'{fpng}\' ' )
-    #plt.show()
+    #plt.show()  # (!) PLEASE comment out the safe backend Agg before using this
 
 
 if __name__ == '__main__':

--- a/pe.audio.sys/share/services/preamp_mod/core.py
+++ b/pe.audio.sys/share/services/preamp_mod/core.py
@@ -33,7 +33,7 @@ import yaml
 import jack
 import numpy as np
 from time import sleep
-import multiprocessing as mp
+import threading
 
 sys.path.append (os.path.dirname(__file__) )
 import bfeq2png
@@ -301,8 +301,8 @@ def bf_set_eq( eq_mag, eq_pha ):
     # (i) Pending threading this, although it is fast to complete.
     #     Notice: threading is not suitable with matplotlib,
     #             tried  multiprocessing but cannot fix OSError.
-    #dump_graph = mp.Process( target=bfeq2png.do_graph,
-    #                         args=(freqs, eq_mag) )
+    #dump_graph = multiprocessing.Process( target=bfeq2png.do_graph,
+    #                                      args=(freqs, eq_mag) )
     #dump_graph.start()
 
 
@@ -475,10 +475,8 @@ def jack_connect_bypattern( cap_pattern, pbk_pattern,
     mode = 'disconnect' if ('dis' in mode or 'off' in mode) else 'connect'
     for i, cap_port in enumerate(cap_ports):
         pbk_port = pbk_ports[i]
-        job_jc = mp.Process( target=jack_connect,
-                             args=(cap_port,
-                                   pbk_port,
-                                   mode, wait) )
+        job_jc = threading.Thread( target=jack_connect,
+                                   args=(cap_port, pbk_port, mode, wait) )
         job_jc.start()
 
 


### PR DESCRIPTION
Rollback to threading, because multiprocessing is not suitable here. Except for jack loops daemon, where multiprocessing is very convenient and efficient since jack loops are independent processes.