### PR TITLE
some updates

### DIFF
--- a/pe.audio.sys/share/scripts/lcd/lcd_daemon.py
+++ b/pe.audio.sys/share/scripts/lcd/lcd_daemon.py
@@ -236,7 +236,7 @@ def update_lcd_state(scr='scr_1'):
                     lbl = ''
                 # Special usage mono label to display if convolver is off
                 if 'convolver_runs' in data and not data['convolver_runs']:
-                    lbl = ' zzz'
+                    lbl = ' zzz' # brutefir is sleeping
 
             # Any else key:
             else:


### PR DESCRIPTION
On this pullreq:

- lcd_daemon.py:   displays 'zzz' when convolver is off

and some recent updates outside this pull req:

- update loudness_monitor:          fix [M] and  [I] events  now created under LU_meter class
- fix start.py checking loops:        avoids counting loops used by more than one input
- update zita-n2j_mcast:               use best metric interface
- update sound_cards_prepare:   fix to call 'pactl' if not available

