### PR TITLE
outputs delay option

### DIFF
--- a/bin/peaudiosys_add_delay.py
+++ b/bin/peaudiosys_add_delay.py
@@ -159,19 +159,33 @@ def set_delay(ms):
 
 if __name__ == '__main__':
 
+    # Redirecting console temporary to ignore pe.audio.sys modules printouts.
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
+    devnull = open('/dev/null', 'w')
+    sys.stdout = devnull
+    sys.stderr = devnull
+
+    # Test if Brutefir is available
+    test = bf_cli('')
+
+    # Getting FS from start.py module
+    FS = int( get_Bfir_sample_rate() )
+
+    # Restoring stdout
+    sys.stdout = original_stdout
+    sys.stderr = original_stderr
+    devnull.close()
+
     # Getting configured outputs
     outputs = get_config_outputs()
 
-    # Getting FS from start.py module, and redirecting
-    # stdout temporary to ignore its printouts.
-    original_stdout = sys.stdout
-    with open('/dev/null', 'w') as devnull:
-        sys.stdout = devnull
-        FS = int( get_Bfir_sample_rate() )
-    sys.stdout = original_stdout
-
     # Reading command line
     if sys.argv[1:]:
+
+        if not test:
+            print( 'Brutefir not available')
+            sys.exit()
 
         if '-l' in sys.argv[1]:
             list_outputs( get_current_outputs() )
@@ -180,7 +194,6 @@ if __name__ == '__main__':
         delay = float(sys.argv[1])
 
         print( set_delay(delay) )
-        #list_outputs( get_current_outputs() )
 
     else:
         print(__doc__)

--- a/pe.audio.sys/README.md
+++ b/pe.audio.sys/README.md
@@ -127,11 +127,11 @@ All commands prefixed with `aux`:
 
     get_LU_monitor                          Gets the monitored LU-I value and scope
     
-    set_LU_monitor_scope  album | track     Choose the LU-I measured scope
+    set_LU_monitor_scope  album | track     Choose the LU-I metering scope
 
     restart                                 Restarts pe.audio.sys
     
-    add_delay   xx                          Delays xx ms the sound card outputs, e.g for multiroom listening.
+    add_delay   xx                          Delays xx ms the sound card outputs, e.g for multiroom listening
 
 
 ## Monitoring the system

--- a/pe.audio.sys/README.md
+++ b/pe.audio.sys/README.md
@@ -131,7 +131,7 @@ All commands prefixed with `aux`:
 
     restart                                 Restarts pe.audio.sys
     
-    add_delay  xx                           Delays xx ms the sound card outputs, can be useful for multiroom listening.
+    add_delay   xx                          Delays xx ms the sound card outputs, e.g for multiroom listening.
 
 
 ## Monitoring the system

--- a/pe.audio.sys/share/services/peaudiosys.py
+++ b/pe.audio.sys/share/services/peaudiosys.py
@@ -265,7 +265,7 @@ def process_aux( cmd, arg='' ):
     elif cmd == 'get_web_config':
         result = WEBCONFIG
 
-    # Add output delay, can be useful for multiroom listening
+    # Add outputs delay, can be useful for multiroom listening
     elif cmd == 'add_delay':
         print(f'({ME}) ordering adding {arg} ms of delay.')
         Popen(f'{UHOME}/bin/peaudiosys_add_delay.py {arg}'.split())

--- a/pe.audio.sys/share/www/clientside.js
+++ b/pe.audio.sys/share/www/clientside.js
@@ -378,7 +378,14 @@ function input_select(iname){
     hold_tmp_msg = 3;
     tmp_msg = 'Please wait for "' + iname + '"';
     document.getElementById("main_cside").innerText = tmp_msg;
-    setTimeout(() => { control_cmd('input ' + iname); }, 200);
+
+    // (i) The arrow syntax '=>' fails on Safari iPad 1 (old version)
+    // setTimeout( () => { control_cmd('input ' + iname); }, 200 );
+    function tmp(iname){
+        control_cmd('input ' + iname);
+    }
+    setTimeout( tmp, 200, iname );  // 'iname' is given as argument for 'tmp'
+
     clear_highlighted();
     document.getElementById('inputsSelector').style.color = "white";
 }
@@ -647,7 +654,14 @@ function run_macro(mFname){
     control_cmd( 'aux run_macro ' + mFname );
     var mName = mFname.slice(mFname.indexOf('_') + 1, mFname.length);
     clear_highlighted();
-    setTimeout(() => { highlight_macro_button(mName);}, 200);
+
+    // (i) The arrow syntax '=>' fails on Safari iPad 1 (old version)
+    // setTimeout(() => { highlight_macro_button(mName);}, 200);
+    function tmp(mName){
+        highlight_macro_button(mName);
+    }
+    setTimeout( tmp, 200, mName );  // 'mName' is given as argument for 'tmp'
+
     hold_tmp_msg = 3;
     tmp_msg = 'Please wait for "' + mName + '"';
 }

--- a/pe.audio.sys/share/www/clientside.js
+++ b/pe.audio.sys/share/www/clientside.js
@@ -804,11 +804,13 @@ function advanced(mode) {
         document.getElementById( "advanced_controls").style.display = "block";
         document.getElementById( "level_buttons13").style.display = "table-cell";
         document.getElementById( "main_lside").style.display = "table-cell";
+        document.getElementById( "RAOD").style.display = "inline-block";
     }
     else {
         document.getElementById( "advanced_controls").style.display = "none";
         document.getElementById( "level_buttons13").style.display = "none";
         document.getElementById( "main_lside").style.display = "none";
+        document.getElementById( "RAOD").style.display = "none";
     }
 }
 

--- a/pe.audio.sys/share/www/index.html
+++ b/pe.audio.sys/share/www/index.html
@@ -116,13 +116,13 @@ along with 'pe.audio.sys'.  If not, see <https://www.gnu.org/licenses/>.
         td#graphs_toggle    { border: none; width: 4%; }
 
 
-        table#level_buttons_table  { table-layout: fixed; }
-        td#level_buttons11   { border-style: none; width:5%; }
-        td#level_buttons12   { border-style: none; width:90%; }
-        td#level_buttons13   { border-style: none; width:5%; }
-        td#level_buttons21   { border-style: none; width:5%; }
-        td#level_buttons22   { border-style: none; width:90%; }
-        td#level_buttons23   { border-style: none; width:5%; }
+        table#level_buttons_table  { }
+        td#level_buttons11   { border-style: none; width:10%; }
+        td#level_buttons12   { border-style: none; width:80%; }
+        td#level_buttons13   { border-style: none; width:10%; }
+        td#level_buttons21   { border-style: none; width:10%; }
+        td#level_buttons22   { border-style: none; width:80%; }
+        td#level_buttons23   { border-style: none; width:10%; }
 
         /* --- LU OFFSET --- */
         td#LU_meter_scope    { width:18%; border-style:none ; font-size:.8em; vertical-align: middle;}
@@ -298,6 +298,11 @@ along with 'pe.audio.sys'.  If not, see <https://www.gnu.org/licenses/>.
                         &nbsp;&nbsp;&nbsp;+3&nbsp;&nbsp;&nbsp;</button>
             </td>
             <td id="level_buttons23">
+                <button type="button" id="RAOD" style="display:none;font-size:0.7em"
+                        title="Remove Added Outputs Delay"
+                        onmousedown="control_cmd('aux add_delay 0')">
+                        RAOD
+                </button>
             </td>
           </tr>
         </table>

--- a/pe.audio.sys/share/www/index_big.html
+++ b/pe.audio.sys/share/www/index_big.html
@@ -119,13 +119,13 @@ along with 'pe.audio.sys'.  If not, see <https://www.gnu.org/licenses/>.
         td#graphs_toggle    { border: none; width: 4%; }
 
 
-        table#level_buttons_table  { table-layout: fixed; }
-        td#level_buttons11   { border-style: none; width:5%; }
-        td#level_buttons12   { border-style: none; width:90%; }
-        td#level_buttons13   { border-style: none; width:5%; }
-        td#level_buttons21   { border-style: none; width:5%; }
-        td#level_buttons22   { border-style: none; width:90%; }
-        td#level_buttons23   { border-style: none; width:5%; }
+        table#level_buttons_table  { }
+        td#level_buttons11   { border-style: none; width:10%; }
+        td#level_buttons12   { border-style: none; width:80%; }
+        td#level_buttons13   { border-style: none; width:10%; }
+        td#level_buttons21   { border-style: none; width:10%; }
+        td#level_buttons22   { border-style: none; width:80%; }
+        td#level_buttons23   { border-style: none; width:10%; }
 
         /* --- LU OFFSET --- */
         td#LU_meter_scope    { width:18%; border-style:none ; font-size:.8em; vertical-align: middle;}
@@ -303,6 +303,11 @@ along with 'pe.audio.sys'.  If not, see <https://www.gnu.org/licenses/>.
                         &nbsp;&nbsp;&nbsp;+3&nbsp;&nbsp;&nbsp;</button>
             </td>
             <td id="level_buttons23">
+                <button type="button" id="RAOD" style="display:none;font-size:0.7em"
+                        title="Remove Added Outputs Delay"
+                        onmousedown="control_cmd('aux add_delay 0')">
+                        RAOD
+                </button>
             </td>
           </tr>
         </table>


### PR DESCRIPTION
Adding delay can be useful for multiroom listening

- new tool bin/peaudiosys_add_delay.py
- new command 'aux add_delay', a wrapper for bin/peaudiosys_add_delay.py, so that remote multiroom systems can adjust it.
- new web button 'RAOD' (remove added output delay)

Others:
clientside.js 'setTimeout' syntax fixed for older iOS devices
