### PR TITLE
update

### DIFF
--- a/pe.audio.sys/README.md
+++ b/pe.audio.sys/README.md
@@ -363,7 +363,6 @@ Here you are an uncommented bare example of `config.yml`:
     restart_cmd: peaudiosys_restart.sh
 
     web_config:
-        hide_macro_buttons: false
         hide_LU: false
         show_graphs: true
         main_selector: 'inputs'

--- a/pe.audio.sys/README.md
+++ b/pe.audio.sys/README.md
@@ -366,7 +366,7 @@ Here you are an uncommented bare example of `config.yml`:
         hide_macro_buttons: false
         hide_LU: false
         show_graphs: true
-        inputs_as_macros: false
+        main_selector: 'inputs'
         
 
     LU_reset_scope: album

--- a/pe.audio.sys/config.yml.sample
+++ b/pe.audio.sys/config.yml.sample
@@ -124,7 +124,7 @@ on_change_input:
 # (i)
 #     - If capture_ports here are named 'xxxxloop', then the preamp will
 #       automagically spawn them for the sources can connect into. Obviously the
-#       sources must be configured accordingly.
+#       sources must be configured accordingly. This applies for MPD and ALSA players.
 #
 #     - xo, drc fields are optional, you may want minimum phase FIRs for video.
 #
@@ -137,19 +137,24 @@ on_change_input:
 sources:
 
     spotify:
-        capture_port:   alsa_loop
+        capture_port:   alsa_loop           # a loop for alsa players
         gain:           0.0
         xo:             
 
     mpd:
-        capture_port:   mpd_loop
+        capture_port:   mpd_loop            # a loop for MPD is needed
         gain:           0.0
         xo:             
 
     istreams:
-        capture_port:   mplayer_istreams
-        gain:           0.0
-        xo:             
+        capture_port:   mplayer_istreams    # remember: ~/.mplayer/config
+        gain:           0.0                 #   [istreams]
+        xo:                                 #   ao=jack:name=mplayer_istreams:noconnect
+    
+    dvb:
+        capture_port:   mplayer_dvb         # remember: ~/.mplayer/config
+        gain:           0.0                 #   [dvb]
+        xo:                                 #   ao=jack:name=mplayer_dvb:noconnect
     
     tv:
         capture_port:   system
@@ -161,7 +166,7 @@ sources:
         capture_port:   zita-n2j
         gain:           0.0
         xo:             
-        address:        192.168.1.234
+        address:        localhost
 
 
 # ========================== SOURCE MONITOR PORTS ==============================

--- a/pe.audio.sys/config.yml.sample
+++ b/pe.audio.sys/config.yml.sample
@@ -224,7 +224,7 @@ scripts:
     ## A LAN multicast audio receiver
     #- zita-n2j_mcast.py
     
-    ## A LAN multicast audio sender
+    ## A LAN multicast audio sender (network BW ~ 1.7 Mb/s 2ch 44100 16bit)
     #- zita-j2n_mcast.py
     
     ## A Spotify Desktop monitor

--- a/pe.audio.sys/config.yml.sample
+++ b/pe.audio.sys/config.yml.sample
@@ -260,14 +260,12 @@ restart_cmd: ~/pe.audio.sys/start.py all
 
 # Control web page behavior
 web_config:
-    # hide macro buttons at web startup
-    hide_macro_buttons: false
     # hide the LU offset slider and the LU monitor bar
     hide_LU: false
     # display EQ and DRC graphs
     show_graphs: true
-    # the main selector can manage inputs or macros:
-    main_selector: 'macros'
+    # the main selector can manage 'inputs' or 'macros':
+    main_selector: 'inputs'
 
 
 # The scope ('input', 'album' or 'track') to trigger to reset the measured LU

--- a/pe.audio.sys/config.yml.sample
+++ b/pe.audio.sys/config.yml.sample
@@ -279,5 +279,3 @@ powersave:              false
 powersave_noise_floor: -70
 powersave_max_wait:     180  # Time in seconds before shutting down Brutefir
 
-# Spotify client, playlists file path:
-spotify_playlists_file: spotify_plists.yml

--- a/pe.audio.sys/config.yml.sample
+++ b/pe.audio.sys/config.yml.sample
@@ -266,8 +266,8 @@ web_config:
     hide_LU: false
     # display EQ and DRC graphs
     show_graphs: true
-    # the input selector can become a macros manager:
-    inputs_as_macros: false
+    # the main selector can manage inputs or macros:
+    main_selector: 'macros'
 
 
 # The scope ('input', 'album' or 'track') to trigger to reset the measured LU

--- a/pe.audio.sys/config.yml.sample
+++ b/pe.audio.sys/config.yml.sample
@@ -137,24 +137,24 @@ on_change_input:
 sources:
 
     spotify:
-        capture_port:   alsa_loop           # a loop for alsa players
+        capture_port:   alsa_loop           # (i) same in ALSA players's config
         gain:           0.0
         xo:             
 
     mpd:
-        capture_port:   mpd_loop            # a loop for MPD is needed
+        capture_port:   mpd_loop            # (i) same in ~/.mpdconf
         gain:           0.0
         xo:             
 
     istreams:
-        capture_port:   mplayer_istreams    # remember: ~/.mplayer/config
-        gain:           0.0                 #   [istreams]
-        xo:                                 #   ao=jack:name=mplayer_istreams:noconnect
+        capture_port:   mplayer_istreams    # (i) same in ~/.mplayer/config
+        gain:           0.0
+        xo:
     
     dvb:
-        capture_port:   mplayer_dvb         # remember: ~/.mplayer/config
-        gain:           0.0                 #   [dvb]
-        xo:                                 #   ao=jack:name=mplayer_dvb:noconnect
+        capture_port:   mplayer_dvb         # (i) same in ~/.mplayer/config
+        gain:           0.0
+        xo:
     
     tv:
         capture_port:   system

--- a/pe.audio.sys/doc/90_FAQ.md
+++ b/pe.audio.sys/doc/90_FAQ.md
@@ -80,3 +80,16 @@ The installed new files will be shown as:
 So now you can symlink it to run the new version:
 
     ln -s /usr/local/bin/brutefir $HOME/bin/brutefir
+    
+## How much network bandwidth does consume zita-j2n (JACK to NETWORK) 
+
+If you use the script **`zita-n2j_mcast.py`**, then UDP multicast packets will be sent continously.
+
+For a typical setting of 2 ch 44100 Hz 16 bit, the used BW is about 1.7 Mb/s over your LAN.
+
+
+
+
+
+
+

--- a/pe.audio.sys/share/miscel.py
+++ b/pe.audio.sys/share/miscel.py
@@ -181,7 +181,14 @@ def set_as_pattern(param, pattern, sender='miscel', verbose=False):
     if param not in ('xo', 'drc', 'target'):
         return "parameter mus be 'xo', 'drc' or 'target'"
 
-    for setName in json_loads( send_cmd(f'get_{param}_sets') ):
+    sets = send_cmd(f'get_{param}_sets')
+    
+    try:
+        sets = json_loads( sets )
+    except:
+        return result
+
+    for setName in sets:
 
         if pattern in setName:
             result = send_cmd( f'set_{param} {setName}',

--- a/pe.audio.sys/share/miscel.py
+++ b/pe.audio.sys/share/miscel.py
@@ -210,9 +210,12 @@ def wait4ports(pattern):
 
 
 # Send a command to a peaudiosys server
-def send_cmd(cmd, sender='', verbose=False, service='peaudiosys'):
+def send_cmd(cmd, sender='', verbose=False, service='peaudiosys', timeout=60):
     """ send commands to a pe.audio.sys server
     """
+    # (i) socket timeout 60 because Brutefir can need some time 
+    #     in slow machines after powersave shot it down.
+
     # (i) start.py will assign 'preamp' port number this way:
     port = {'peaudiosys':   SRV_BASE_PORT,
             'preamp':       SRV_BASE_PORT + 1,
@@ -228,7 +231,7 @@ def send_cmd(cmd, sender='', verbose=False, service='peaudiosys'):
     # (i) We prefer high-level socket function 'create_connection()',
     #     rather than low level 'settimeout() + connect()'
     try:
-        with socket.create_connection( (SRV_HOST, port), timeout=3 ) as s:
+        with socket.create_connection( (SRV_HOST, port), timeout=timeout ) as s:
             s.send( cmd.encode() )
             if verbose:
                 print( f'{Fmt.BLUE}({sender}) Tx: to   {service}: \'{cmd}\'{Fmt.END}' )

--- a/pe.audio.sys/share/scripts/zita-j2n_mcast.py
+++ b/pe.audio.sys/share/scripts/zita-j2n_mcast.py
@@ -9,6 +9,9 @@
         sound cards of the systems using it
 
     usage:    zita-j2n_mcast.py   start | stop
+    
+    NOTICE: 2 ch 44100 Hz 16 bit will use about ~ 1.7 Mb/s network bandwidth
+            (UDP packets)
 
 """
 import sys

--- a/pe.audio.sys/share/server.py
+++ b/pe.audio.sys/share/server.py
@@ -36,12 +36,17 @@ def run_server(host, port, verbose=False):
     """ Inside this simple server, it is called the desired PROCESSING MODULE to
         request the actual service action then will return back the action result.
     """
+    # UNDERSTANDING A SERVER:
     # https://realpython.com/python-sockets/#echo-client-and-server
     # One thing that’s imperative to understand is that we now have
     # a new socket object from accept(). This is important since
     # it’s the socket that you’ll use to communicate with the client.
     # It’s distinct from the listening socket that the server is using
     # to accept new connections
+
+    # (i) In a future, Python 3.8 will provide a higher level function
+    #     'create_server()' that can replace the below 4 commands for
+    #     srv creation. In the meanwhile, lets use the well known procedure:
 
     # Prepare the server (the 1st listening socket)
     srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/pe.audio.sys/share/services/peaudiosys.py
+++ b/pe.audio.sys/share/services/peaudiosys.py
@@ -21,16 +21,17 @@
     This module is loaded by 'server.py'
 """
 
-import os
+from os import scandir
+from os.path import expanduser, exists, getsize
 import sys
-UHOME       = os.path.expanduser("~")
+UHOME = expanduser("~")
 sys.path.append(f'{UHOME}/pe.audio.sys')
 
 from share.miscel import *
 import yaml
 import json
 from subprocess import Popen
-from time import sleep
+from time import sleep, strftime
 #   https://watchdog.readthedocs.io/en/latest/
 from watchdog.observers import Observer
 from watchdog.events    import FileSystemEventHandler
@@ -48,6 +49,13 @@ AUX_INFO = {    'amp':              'off',
                 'last_macro':       '-',    # cannot be empty
                 'web_config':       {}
             }
+
+
+# COMMAND LOG FILE
+logFname = f'{UHOME}/pe.audio.sys/.peaudiosys_cmd.log'
+if exists(logFname) and getsize(logFname) > 2e6:
+    print ( f"{Fmt.RED}(peaudiosys) log file exceeds ~ 2 MB '{logFname}'{Fmt.END}" )
+print ( f"{Fmt.BLUE}(peaudiosys) logging commands in '{logFname}'{Fmt.END}" )
 
 
 # Read the amplifier state file, if it exists:
@@ -168,7 +176,7 @@ def process_aux( cmd, arg='' ):
 
 
     # BEGIN of process_aux
-    result = ''
+    result = 'bad command'
 
     # AMPLIFIER SWITCHING
     if cmd == 'amp_switch':
@@ -198,7 +206,7 @@ def process_aux( cmd, arg='' ):
     # LIST OF MACROS under macros/ folder (numeric sorted)
     elif cmd == 'get_macros':
         macro_files = []
-        with os.scandir( f'{MACROS_FOLDER}' ) as entries:
+        with scandir( f'{MACROS_FOLDER}' ) as entries:
             for entrie in entries:
                 fname = entrie.name
                 if fname.split('_')[0].isdigit():
@@ -336,9 +344,9 @@ def init():
 
 
 # Interface function to plug this on server.py
-def do( command_phrase ):
+def do( cmd_phrase ):
 
-    def read_command_phrase(command_phrase):
+    def read_cmd_phrase(cmd_phrase):
 
         # (i) command phrase SYNTAX must start with an appropriate prefix:
         #           preamp  command  arg1 ...
@@ -349,8 +357,8 @@ def do( command_phrase ):
         pfx, cmd, arg = '', '', ''
 
         # This is to avoid empty values when there are more
-        # than on space as delimiter inside the command_phrase:
-        chunks = [x for x in command_phrase.split(' ') if x]
+        # than on space as delimiter inside the cmd_phrase:
+        chunks = [x for x in cmd_phrase.split(' ') if x]
 
         # If not prefix, will treat as a preamp command kind of
         if not chunks[0] in ('preamp', 'player', 'aux'):
@@ -360,7 +368,7 @@ def do( command_phrase ):
         if chunks[1:]:
             cmd = chunks[1]
         else:
-            raise Exception(f'({ME}) BAD command: {command_phrase}')
+            raise Exception(f'({ME}) BAD command: {cmd_phrase}')
         if chunks[2:]:
             # allows spaces inside the arg part, e.g. 'run_macro 2_Radio Clasica'
             arg = ' '.join( chunks[2:] )
@@ -368,9 +376,10 @@ def do( command_phrase ):
         return pfx, cmd, arg
 
     result = 'nothing done'
-
-    if command_phrase.strip():
-        pfx, cmd, arg = read_command_phrase( command_phrase.strip() )
+    cmd_phrase = cmd_phrase.strip()
+    
+    if cmd_phrase.strip():
+        pfx, cmd, arg = read_cmd_phrase( cmd_phrase )
         #print('pfx:', pfx, '| cmd:', cmd, '| arg:', arg) # DEBUG
         if cmd == 'help':
             Popen( f'cat {MAINFOLDER}/doc/peaudiosys.hlp', shell=True)
@@ -381,5 +390,11 @@ def do( command_phrase ):
                     'aux':      process_aux }[ pfx ]( cmd, arg )
         if type(result) != str:
             result = json.dumps(result)
+
+        # Command log ~ estimated growing size: pending
+        if 'state' not in cmd_phrase:
+            with open(logFname, 'a') as FLOG:
+                FLOG.write(f'{strftime("%Y/%m/%d %H:%M:%S")}; {cmd_phrase}; '
+                           f'{result}\n')
 
     return result

--- a/pe.audio.sys/share/services/peaudiosys.py
+++ b/pe.audio.sys/share/services/peaudiosys.py
@@ -391,7 +391,7 @@ def do( cmd_phrase ):
         if type(result) != str:
             result = json.dumps(result)
 
-        # Command log ~ estimated growing size: pending
+        # Command log
         if 'state' not in cmd_phrase:
             with open(logFname, 'a') as FLOG:
                 FLOG.write(f'{strftime("%Y/%m/%d %H:%M:%S")}; {cmd_phrase}; '

--- a/pe.audio.sys/share/services/peaudiosys.py
+++ b/pe.audio.sys/share/services/peaudiosys.py
@@ -134,12 +134,12 @@ def process_aux( cmd, arg='' ):
         wconfig['LU_monitor_enabled'] = True if 'loudness_monitor.py' \
                                                   in CONFIG['scripts'] else False
 
-        # Special behavior for inputs selector as macros manager
-        if not 'inputs_as_macros' in wconfig:
-            wconfig["inputs_as_macros"] = False
+        # main selector manages inputs or macros
+        if not 'main_selector' in wconfig:
+            wconfig["main_selector"] = 'inputs';
         else:
-            if wconfig["inputs_as_macros"] != True:
-                wconfig["inputs_as_macros"] = False
+            if wconfig["main_selector"] not in ('inputs', 'macros'):
+                wconfig["main_selector"] = 'inputs'
 
         return wconfig
 
@@ -195,7 +195,7 @@ def process_aux( cmd, arg='' ):
 
         return result
 
-    # LIST OF MACROS under macros/ folder
+    # LIST OF MACROS under macros/ folder (numeric sorted)
     elif cmd == 'get_macros':
         macro_files = []
         with os.scandir( f'{MACROS_FOLDER}' ) as entries:

--- a/pe.audio.sys/share/services/peaudiosys.py
+++ b/pe.audio.sys/share/services/peaudiosys.py
@@ -52,13 +52,13 @@ AUX_INFO = {    'amp':              'off',
 
 # Read the amplifier state file, if it exists:
 def get_amp_state():
-    curr_sta = '-'
+    curr_sta = 'off'
     try:
         with open( f'{AMP_STATE_FILE}', 'r') as f:
             curr_sta =  f.read().strip()
     except:
         pass
-    if curr_sta.lower() in ('0', 'off'):
+    if not curr_sta or curr_sta.lower() in ('0', 'off'):
         curr_sta = 'off'
     elif curr_sta.lower() in ('1', 'on'):
         curr_sta = 'on'

--- a/pe.audio.sys/share/services/peaudiosys.py
+++ b/pe.audio.sys/share/services/peaudiosys.py
@@ -379,6 +379,12 @@ def do( cmd_phrase ):
     cmd_phrase = cmd_phrase.strip()
     
     if cmd_phrase.strip():
+
+        # cmd_phrase log
+        if 'state' not in cmd_phrase and 'get_' not in cmd_phrase:
+            with open(logFname, 'a') as FLOG:
+                FLOG.write(f'{strftime("%Y/%m/%d %H:%M:%S")}; {cmd_phrase}; ')
+
         pfx, cmd, arg = read_cmd_phrase( cmd_phrase )
         #print('pfx:', pfx, '| cmd:', cmd, '| arg:', arg) # DEBUG
         if cmd == 'help':
@@ -391,10 +397,9 @@ def do( cmd_phrase ):
         if type(result) != str:
             result = json.dumps(result)
 
-        # Command log
-        if 'state' not in cmd_phrase:
+        # result log
+        if 'state' not in cmd_phrase and 'get_' not in cmd_phrase:
             with open(logFname, 'a') as FLOG:
-                FLOG.write(f'{strftime("%Y/%m/%d %H:%M:%S")}; {cmd_phrase}; '
-                           f'{result}\n')
+                FLOG.write(f'{result}\n')
 
     return result

--- a/pe.audio.sys/share/services/players.py
+++ b/pe.audio.sys/share/services/players.py
@@ -242,10 +242,15 @@ def do(cmd_phrase):
         - out:  a string result (dicts are json dumped)
     """
 
+    cmd_phrase = cmd_phrase.strip()
     result = 'nothing done'
 
+    # cmd_phrase log
+    if 'state' not in cmd_phrase and 'get_' not in cmd_phrase:
+        with open(logFname, 'a') as FLOG:
+            FLOG.write(f'{strftime("%Y/%m/%d %H:%M:%S")}; {cmd_phrase}; ')
+
     # Reading command phrase:
-    cmd_phrase = cmd_phrase.strip()
     cmd, arg = '', ''
     chunks = cmd_phrase.split(' ')
     cmd = chunks[0]
@@ -285,10 +290,9 @@ def do(cmd_phrase):
     if type(result) != str:
         result = json.dumps(result)
 
-    # Command log
-    if 'state' not in cmd_phrase:
+    # result log
+    if 'state' not in cmd_phrase and 'get_' not in cmd_phrase:
         with open(logFname, 'a') as FLOG:
-            FLOG.write(f'{strftime("%Y/%m/%d %H:%M:%S")}; {cmd_phrase}; '
-                       f'{result}\n')
+            FLOG.write(f'{result}\n')
 
     return result

--- a/pe.audio.sys/share/services/players_mod/mplayer.py
+++ b/pe.audio.sys/share/services/players_mod/mplayer.py
@@ -262,7 +262,8 @@ def mplayer_control(cmd, service):
                             'next',
                             'previous',
                             'rew',
-                            'ff'        )
+                            'ff',
+                            'eject'     )
 
     # (i) pe.audio.sys scripts redirects Mplayer stdout & stderr
     #     towards special files:

--- a/pe.audio.sys/share/services/players_mod/mplayer.py
+++ b/pe.audio.sys/share/services/players_mod/mplayer.py
@@ -264,16 +264,24 @@ def mplayer_control(cmd, service):
                             'rew',
                             'ff'        )
 
-    # (i) Mplayer sends its responses to the terminal where Mplayer
-    #     was launched, or to a redirected file.
+    # (i) pe.audio.sys scripts redirects Mplayer stdout & stderr
+    #     towards special files:
+    #       ~/pe.audio.sys/.<service>_events
+    #     so that will capture there the Mplayer's answers when
+    #     a Mplayer command has been issued.
     #     Available commands: http://www.mplayerhq.hu/DOCS/tech/slave.txt
 
     status = playing_status()
 
-    # Early return if no action commands or not supported command:
-    if cmd == 'state' or cmd not in supported_commands:
+    # Early return if SLAVE GETTING INFO commands:
+    if cmd.startswith('get_'):
+        send_cmd( cmd, service )
+        return status
+    # Early return if STATE or NOT SUPPORTED command:
+    elif cmd == 'state'or cmd not in supported_commands:
         return status
 
+    # Special command EJECT
     if cmd == 'eject':
         Popen( f'eject {cdda.CDROM_DEVICE}'.split() )
         # Flush .cdda_info
@@ -283,7 +291,7 @@ def mplayer_control(cmd, service):
         send_cmd('stop', service)
         return playing_status()
 
-    # Action commands i.e. playback control
+    # Processing ACTION commands (playback control)
     if service == 'istreams':
 
         # useful when playing a mp3 stream (e.g. a podcast url)
@@ -427,11 +435,9 @@ def mplayer_meta(md, service):
     with open(mplayer_redirection_path, 'r') as file:
         try:
             # get last 4 lines plus the empty one when splitting
-            tmp = file.read().split('\n')[-5:]
+            tmp = file.read().replace('\x00', '').split('\n')[-5:]
         except:
             tmp = []
-
-    #print('DEBUG\n', tmp)
 
     # Flushing the Mplayer output file to avoid continue growing:
     with open(mplayer_redirection_path, 'w') as file:

--- a/pe.audio.sys/share/services/players_mod/spotify_desktop.py
+++ b/pe.audio.sys/share/services/players_mod/spotify_desktop.py
@@ -41,12 +41,13 @@ except:
 SPOTIFY_BITRATE   = '320'
 
 # User playlists
-try:
-    CONFIG = yaml.safe_load( open(f'{MAINFOLDER}/config.yml', 'r') )
-    plist_file = CONFIG['spotify_playlists_file']
-    PLAYLISTS = yaml.safe_load(open(plist_file, 'r'))
-except:
-    PLAYLISTS = {}
+plist_file = f'{MAINFOLDER}/spotify_plists.yml'
+PLAYLISTS = {}
+if os.path.exists(plist_file):
+    try:
+        PLAYLISTS = yaml.safe_load(open(plist_file, 'r'))
+    except:
+        print(f'(spotify_desktop.py) ERROR reading \'{plist_file}\'')
 
 # Auxiliary function to format hh:mm:ss
 def timeFmt(x):

--- a/pe.audio.sys/share/services/preamp.py
+++ b/pe.audio.sys/share/services/preamp.py
@@ -191,17 +191,24 @@ def process_commands( full_command ):
 def do( cmd_phrase ):
 
     cmd_phrase = cmd_phrase.strip()
+    result = 'nothing done'
+
+    # cmd_phrase log
+    if 'state' not in cmd_phrase and 'get_' not in cmd_phrase:
+        with open(logFname, 'a') as FLOG:
+            FLOG.write(f'{strftime("%Y/%m/%d %H:%M:%S")}; {cmd_phrase}; ')
+
     result = process_commands( cmd_phrase )
 
     if type(result) != str:
         result = json.dumps(result)
 
-    if result:
+    if result != 'nothing done':
         preamp.save_state()
 
-    # Command log
-    if 'state' not in cmd_phrase:
+    # result log
+    if 'state' not in cmd_phrase and 'get_' not in cmd_phrase:
         with open(logFname, 'a') as FLOG:
-            FLOG.write(f'{strftime("%Y/%m/%d %H:%M:%S")}; {cmd_phrase}; {result}\n')
+            FLOG.write(f'{result}\n')
         
     return result

--- a/pe.audio.sys/share/services/preamp.py
+++ b/pe.audio.sys/share/services/preamp.py
@@ -199,7 +199,7 @@ def do( cmd_phrase ):
     if result:
         preamp.save_state()
 
-    # Command log ~ estimated growing size: < 1 MB per year
+    # Command log
     if 'state' not in cmd_phrase:
         with open(logFname, 'a') as FLOG:
             FLOG.write(f'{strftime("%Y/%m/%d %H:%M:%S")}; {cmd_phrase}; {result}\n')

--- a/pe.audio.sys/share/services/preamp_mod/core.py
+++ b/pe.audio.sys/share/services/preamp_mod/core.py
@@ -1001,7 +1001,7 @@ class Preamp(object):
         # (i)
         # 'config.yml' SOURCE's GAIN are set arbitrarily at the USER's OWN RISK,
         # so we exclude it from the headroom calculation.
-        # So although 'gmax: 0.0' (this is digital domain alowed gain), 
+        # So although 'gmax: 0.0' (this is digital domain alowed gain),
         # if a source had gain: 6.0, the real 'gain' on Brutefir level stage
         # can be up to +6.0 dB because of this consideration.
         if candidate["input"] != 'none':
@@ -1009,6 +1009,9 @@ class Preamp(object):
                 input_gain = float( CONFIG["sources"][candidate["input"]]["gain"] )
             except:
                 input_gain = 0.0
+        else:
+            input_gain = 0.0
+
         headroom += input_gain
 
         if headroom >= 0:

--- a/pe.audio.sys/share/www/index.html
+++ b/pe.audio.sys/share/www/index.html
@@ -257,11 +257,15 @@
                 <button id="url_button"
                         title = "enter an URL to be played"
                         style="text-align:center;font-size:0.7em;display:none"
-                        onclick="play_url()">&#9901;
+                        onclick="play_url()">
+                    &#9901;
                 </button>
-                <button type="button" id="track_selector" title="Enter a track number" onmousedown="select_track()" >#</button>
-                <select id="inputsSelector"
-                        title="Source Selector" onchange="input_select(this.value)" ></select>
+                <button type="button" id="track_selector" title="Enter a track number" onmousedown="select_track()" >
+                    #
+                </button>
+                <select id="mainSelector"
+                        title="Source Selector" onchange="main_select(this.value)" >
+                </select>
             </td>
         </tr>
         <tr>
@@ -459,7 +463,10 @@
             </td>
             <!-- MACROS button toggle-->
             <td id="playback_control_23" >
-                <button type="button" id="macros_toggle_button"  onmousedown="macros_toggle()">::</button>
+                <button type="button" id="macros_toggle_button"  onmousedown="macros_toggle()"
+                        title="Toggle macro buttons">
+                    ::
+                </button>
             </td>
         </tr>
       </table>
@@ -468,7 +475,7 @@
     <!-- MACRO BUTTONS can be toggled -->
     <!-- Nx3 buttons keypad for customizable user macros -->
     <div>
-      <table id="macro_buttons" style="display:none">
+      <table id="macro_buttons" style="display:inline-table">
       </table>
     </div>
 

--- a/pe.audio.sys/share/www/index.html
+++ b/pe.audio.sys/share/www/index.html
@@ -222,7 +222,7 @@
     <table id="main_title" >
         <tr>
             <td id="main_lside" style="display:none">
-                <button id="restart_switch" title="RESTART" style="font-size:0.7em" onclick="peaudiosys_restart()">&#9851;</button>
+                <button id="restart_switch" title="RESTART" style="font-size:0.7em" onclick="peaudiosys_restart()">&#128585;</button>
             </td>
             <td id="main_cside"></td>
             <td id="main_rside">

--- a/pe.audio.sys/share/www/index_big.html
+++ b/pe.audio.sys/share/www/index_big.html
@@ -217,7 +217,7 @@
     <table id="main_title" >
         <tr>
             <td id="main_lside" style="display:none">
-                <button id="restart_switch" title="RESTART" style="font-size:0.7em" onclick="peaudiosys_restart()">&#9851;</button>
+                <button id="restart_switch" title="RESTART" style="font-size:0.7em" onclick="peaudiosys_restart()">&#128585;</button>
             </td>
             <td id="main_cside"></td>
             <td id="main_rside">

--- a/pe.audio.sys/share/www/index_big.html
+++ b/pe.audio.sys/share/www/index_big.html
@@ -252,13 +252,17 @@
                 <button id="url_button"
                         title = "enter an URL to be played"
                         style="text-align:center;font-size:0.7em;display:none"
-                        onclick="play_url()">&#9901;
+                        onclick="play_url()">
+                    &#9901;
                 </button>
-                <button type="button" id="track_selector" onmousedown="select_track()" >#</button>
-                <select id="inputsSelector"
+                <button type="button" id="track_selector" onmousedown="select_track()" >
+                    #
+                </button>
+                <select id="mainSelector"
                         title="Source Selector"
-                        onchange="control_cmd('input ' + this.value, update=false)"
-                        style="font-size:1.5em" ></select>
+                        onchange="main_select(this.value)"
+                        style="font-size:1.5em" >
+                </select>
             </td>
         </tr>
         <tr>
@@ -465,7 +469,7 @@
     <!-- MACRO BUTTONS can be toggled -->
     <!-- Nx3 buttons keypad for customizable user macros -->
     <div>
-      <table id="macro_buttons" style="display:none">
+      <table id="macro_buttons" style="display:inline-table">
       </table>
     </div>
 

--- a/pe.audio.sys/start.py
+++ b/pe.audio.sys/start.py
@@ -132,10 +132,13 @@ def start_jackd():
                     .replace('$autoCard', CONFIG["system_card"]) \
                     .replace('$autoFS', str(get_Bfir_sample_rate()))
 
-    cmdlist = ['jackd'] + f'{CONFIG["jack_options"]}'.split() + \
-              f'{jack_backend_options}'.split()
+    cmdlist = ['jackd']
 
-    #print(' '.join(cmdlist)) ; sys.exit() # DEBUG
+    if logFlag:
+        cmdlist += ['--silent']
+
+    cmdlist += f'{CONFIG["jack_options"]}'.split() + \
+               f'{jack_backend_options}'.split()
 
     if 'pulseaudio' in sp.check_output("pgrep -fl pulseaudio",
                                        shell=True).decode():
@@ -351,17 +354,24 @@ if __name__ == "__main__":
 
     # READING OPTIONS FROM COMMAND LINE
     logFlag = False
+
     if sys.argv[1:]:
         mode = sys.argv[1]
     else:
         print(__doc__)
         sys.exit()
+
     if sys.argv[2:] and '-l' in sys.argv[2]:
         logFlag = True
+
     if mode not in ['all', 'stop', 'services', 'scripts']:
         print(__doc__)
         sys.exit()
+
     if logFlag:
+        print('\n' + '-' * 80)
+        print(f'start process logged at \'{MAINFOLDER}/start.log\'')
+        print('-' * 80)
         flog = open(f'{MAINFOLDER}/start.log', 'w')
         original_stdout = sys.stdout
         original_stderr = sys.stderr
@@ -425,7 +435,3 @@ if __name__ == "__main__":
             sender='start.py', verbose=True )
 
     # END
-    if logFlag:
-        sys.stdout = original_stdout
-        sys.stderr = original_stderr
-        print(f'start process logged at \'{MAINFOLDER}/start.log\'')


### PR DESCRIPTION
- miscel.send_cmd: now with timeout, also create_connection() replaces settimeout() + connect()

- fix input gain for fake source 'none' in preamp.py

- fix cdda.py for 'cdstub' musicbrainz database cdda discs

- classical/macros main selector behavior improved

- fix supported commands in mplayer.py

- services log files improved

- informaton about zita j2n multicast LAN bandwidth

- spotify_plist.yml assumed to be placed in pe.audio.sys/
