### PR TITLE
update

### DIFF
--- a/bin/peaudiosys_view_brutefir.py
+++ b/bin/peaudiosys_view_brutefir.py
@@ -71,7 +71,7 @@ def read_config():
     """ reads outputsMap, coeffs, filters_at_start
     """
     global outputsMap, coeffs, filters_at_start
-    global sampling_rate, filter_length, float_bits, dither, init_delays
+    global sampling_rate, filter_length, float_bits, dither, init_delays, maxdelay
 
     with open(BRUTEFIR_CONFIG_PATH, 'r') as f:
         lineas = f.readlines()
@@ -89,11 +89,12 @@ def read_config():
     filterIndex = -1
     filterIniciado = False
 
-    sampling_rate   = None
-    filter_length   = None
-    float_bits      = None
-    dither          = None
-    delay           = None
+    sampling_rate   = ''
+    filter_length   = ''
+    float_bits      = ''
+    dither          = ''
+    delay           = ''
+    maxdelay        = '(as needed)'
 
     # Loops reading lines in brutefir.config (skip lines commented out)
     for linea in [x for x in lineas if (x.strip() and x.strip()[0] != '#') ]:
@@ -110,9 +111,11 @@ def read_config():
         if 'dither' in linea:
             dither = linea.strip().split(':')[-1].strip()
 
-        if 'delay' in linea:
+        if linea.strip().split()[0] == 'delay:':
             init_delays = linea.strip().split(':')[-1].strip()
 
+        if linea.strip().split()[0] == 'maxdelay:':
+            maxdelay = linea.strip().split()[1].strip()
 
 
         #######################
@@ -323,12 +326,13 @@ if __name__ == "__main__" :
         print( output[0].ljust(10), '-->   ', output[1] )
 
     print()
-    print( f'sampling_rate:  {sampling_rate}')
-    print( f'filter_length:  {filter_length}')
-    print( f'float_bits:     {float_bits}')
-    print( f'output_dither:  {dither}')
-    print( f'outputs_delays: {init_delays}   (at init)')
-    print( color.BOLD + f'                {curr_delays};   (CURRENT)' + color.END)
+    print( f'sampling_rate:    {sampling_rate}')
+    print( f'filter_length:    {filter_length}')
+    print( f'float_bits:       {float_bits}')
+    print( f'output_dither:    {dither}')
+    print( f'output_maxdelay:  {maxdelay}')
+    print( f'outputs_delays:   {init_delays}   (at init)')
+    print( color.BOLD + f'                  {curr_delays};   (CURRENT)' + color.END)
 
     print()
     print( "--- Coeff available:" )

--- a/pe.audio.sys/config.yml.sample
+++ b/pe.audio.sys/config.yml.sample
@@ -218,6 +218,9 @@ scripts:
     ## librespot (a headless Spotify Connect player daemon)
     #- librespot.py
     
+    ## A Spotify Desktop monitor
+    #- spotify_monitor.py
+    
     ## Plays audio streamed from AirPlay sources
     #- shairport-sync.py
     
@@ -226,9 +229,6 @@ scripts:
     
     ## A LAN multicast audio sender (network BW ~ 1.7 Mb/s 2ch 44100 16bit)
     #- zita-j2n_mcast.py
-    
-    ## A Spotify Desktop monitor
-    #- spotify_monitor.py
     
     ## Controls the volume by a mouse
     #- mouse_volume_daemon.py

--- a/pe.audio.sys/share/miscel.py
+++ b/pe.audio.sys/share/miscel.py
@@ -279,7 +279,7 @@ def check_Mplayer_config_file(profile='istreams'):
 
 
 # Auxiliary to detect the Spotify Client in use: desktop or librespot
-def detect_spotify_client(timeout=5):
+def detect_spotify_client(timeout=10):
     """ the timeout will wait some seconds for the client to be running
     """
     result = ''

--- a/pe.audio.sys/share/services/preamp_mod/core.py
+++ b/pe.audio.sys/share/services/preamp_mod/core.py
@@ -42,11 +42,21 @@ sys.path.append(MAINFOLDER)
 from share.miscel import Fmt
 
 
-# JCLI: the client interface to the jack server ================================
-try:
-    JCLI = jack.Client('core', no_start_server=True)
-except:
-    print( '(core) ERROR cannot commuticate to the JACK SOUND SERVER.' )
+# JCLI: the client interface to the JACK server ================================
+tries = 15 #  15 * 1/5 s = 3 s
+print( f'{Fmt.BOLD}(core) connecting to JACK ', end='' )
+while tries:
+    try:
+        JCLI = jack.Client('core', no_start_server=True)
+        break
+    except:
+        print( f'.', end='' )
+    tries -=1
+    sleep(.2)
+print(Fmt.END)
+if not tries:
+    # BYE :-/
+    raise ValueError( '(core) ERROR cannot commuticate to the JACK SOUND SERVER')
 
 
 # AUX and FILES MANAGEMENT: ====================================================
@@ -702,9 +712,9 @@ def init_source():
     preamp = Preamp()
 
     if CONFIG["on_init"]["input"]:
-        preamp.select_source  (   CONFIG["on_init"]["input"]      )
+        preamp.select_source  ( CONFIG["on_init"]["input"] )
     else:
-        preamp.select_source  (   preamp.state["input"]             )
+        preamp.select_source  ( preamp.state["input"] )
 
     preamp.save_state()
     del(preamp)

--- a/pe.audio.sys/share/services/preamp_mod/core.py
+++ b/pe.audio.sys/share/services/preamp_mod/core.py
@@ -706,20 +706,6 @@ def jack_clear_preamp():
 
 
 # THE PREAMP: AUDIO PROCESSOR, SELECTOR, and SYSTEM STATE KEEPER ===============
-def init_source():
-    """ Forcing if indicated on config.yml or restoring last state from disk
-    """
-    preamp = Preamp()
-
-    if CONFIG["on_init"]["input"]:
-        preamp.select_source  ( CONFIG["on_init"]["input"] )
-    else:
-        preamp.select_source  ( preamp.state["input"] )
-
-    preamp.save_state()
-    del(preamp)
-
-
 def init_audio_settings():
     """ Forcing if indicated on config.yml or restoring last state from disk
     """
@@ -728,11 +714,6 @@ def init_audio_settings():
         """ Try to set a value defined under CONFIG['on_init'][prop]
             Returns a warning or an empty string
         """
-
-        # Skipping 'input' because it is processed apart at init_source().
-        if prop == 'input':
-            return ''
-
         value = CONFIG["on_init"][prop]
 
         # Skipping if not defined
@@ -747,6 +728,7 @@ def init_audio_settings():
         func = {
                 'xo':               convolver.set_xo,
                 'drc':              convolver.set_drc,
+                'input':            preamp.select_source,
                 'target':           preamp.set_target,
                 'level':            preamp.set_level,
                 'muted':            preamp.set_mute,

--- a/pe.audio.sys/start.py
+++ b/pe.audio.sys/start.py
@@ -342,9 +342,6 @@ if __name__ == "__main__":
         print(f'({ME}) Bye!')
         sys.exit()
 
-    # The 'peaudiosys' service always runs, so that we can do basic operation
-    manage_server(mode='start')
-
     if mode in ('all'):
         # If necessary will prepare drc graphs for the web page
         if CONFIG["web_config"]["show_graphs"]:
@@ -355,28 +352,31 @@ if __name__ == "__main__":
             print(f'({ME}) Problems starting JACK ')
             sys.exit()
 
-        # (i) Importing core.py needs JACK to be running
-        import share.services.preamp_mod.core as core
-
     if mode in ('all', 'scripts'):
         # Running USER SCRIPTS
         run_scripts()
+
+    # Init audio by importing 'core' temporally (needs JACK to be running)
+    import share.services.preamp_mod.core as core
 
     if mode in ('all'):
         # BRUTEFIR
         core.restart_and_reconnect_brutefir( ['pre_in_loop:output_1',
                                               'pre_in_loop:output_2'] )
-        # RESTORE settings
+        # RESTORE on_init config settings
         core.init_audio_settings()
         # PREAMP  --> MONITORS
         core.connect_monitors()
-        # RESTORE source
-        core.init_source()
 
     if mode in ('all', 'server'):
         # Will update Brutefir EQ graph for the web page
         if CONFIG["web_config"]["show_graphs"]:
             update_bfeq_graph()
+
+    del core
+
+    # The 'peaudiosys' service always runs, so that we can do basic operation
+    manage_server(mode='start')
 
     if mode in ('all'):
         # OPTIONAL USER MACRO

--- a/pe.audio.sys/start.py
+++ b/pe.audio.sys/start.py
@@ -157,6 +157,8 @@ def start_jackd():
         print(f'({ME}) waiting for jackd ' + '.' * tries)
         sleep(.5)
         tries -= 1
+    # Still will wait a few
+    sleep(.2)
 
     if tries:
 

--- a/pe.audio.sys/start.py
+++ b/pe.audio.sys/start.py
@@ -380,7 +380,8 @@ if __name__ == "__main__":
         # OPTIONAL USER MACRO
         if 'run_macro' in CONFIG:
             mname = CONFIG["run_macro"]
-            print( f'{Fmt.BLUE}({ME}) triyng macro \'{mname}\'{Fmt.END}' )
-            send_cmd( f'aux run_macro {mname}', sender='start.py', verbose=True )
+            if mname:
+                print( f'{Fmt.BLUE}({ME}) triyng macro \'{mname}\'{Fmt.END}' )
+                send_cmd( f'aux run_macro {mname}', sender='start.py', verbose=True )
 
     # END

--- a/pe.audio.sys/start.py
+++ b/pe.audio.sys/start.py
@@ -356,24 +356,27 @@ if __name__ == "__main__":
         # Running USER SCRIPTS
         run_scripts()
 
-    # Init audio by importing 'core' temporally (needs JACK to be running)
-    import share.services.preamp_mod.core as core
-
     if mode in ('all'):
-        # BRUTEFIR
+
+        # INIT AUDIO by importing 'core' temporally (needs JACK to be running)
+        import share.services.preamp_mod.core as core
+
+        # - BRUTEFIR
         core.restart_and_reconnect_brutefir( ['pre_in_loop:output_1',
                                               'pre_in_loop:output_2'] )
-        # RESTORE on_init config settings
+        # - RESTORE on_init config settings
         core.init_audio_settings()
-        # PREAMP  --> MONITORS
+
+        # - PREAMP  --> MONITORS
         core.connect_monitors()
+
+        del core
+
 
     if mode in ('all', 'server'):
         # Will update Brutefir EQ graph for the web page
         if CONFIG["web_config"]["show_graphs"]:
             update_bfeq_graph()
-
-    del core
 
     # The 'peaudiosys' service always runs, so that we can do basic operation
     manage_server(mode='start')

--- a/pe.audio.sys/start.py
+++ b/pe.audio.sys/start.py
@@ -157,7 +157,7 @@ def start_jackd():
         print(f'({ME}) waiting for jackd ' + '.' * tries)
         sleep(.5)
         tries -= 1
-    # Still will wait a few
+    # Still will wait a few, convenient for fast CPUs
     sleep(.2)
 
     if tries:


### PR DESCRIPTION
- start.py:
    - improved run macro
    - sleep a bit after detecting jack running avoids python jack client to crash in fast CPUs
    - init_audio_settings() now includes init_source()
    - server moved to the very end

- core.py: 
    - JCLI improved
    - init_audio_settings() now includes init_source()

- bin/view_brutefir includes the configured maxdelay info
