### PR TITLE
Anacron updates

### DIFF
--- a/.install/crontab/auto_update_cronjob
+++ b/.install/crontab/auto_update_cronjob
@@ -1,3 +1,3 @@
 
-# Update pe.audio.sys from AudioHumLab (master branch) every day
-00  04  *   *   *   sh $HOME/tmp/download_peaudiosys.sh --auto; sh $HOME/tmp/update_peaudiosys.sh --auto
+# Queries anacron to update pe.audio.sys from AudioHumLab (master branch) every day
+@hourly  /usr/sbin/anacron -s -t $HOME/pe.audio.sys/config/anacrontab -S $HOME/pe.audio.sys/log

--- a/.install/crontab/set_auto_update_cronjob.sh
+++ b/.install/crontab/set_auto_update_cronjob.sh
@@ -39,7 +39,7 @@ else
     # or use this to remove similar lines as per the below given patterns
     p="update pe.audio.sys"
     grep -Fvi "$p" $HOME/tmp/new_crontab > $HOME/tmp/tmp && mv $HOME/tmp/tmp $HOME/tmp/new_crontab
-    p="update_peaudiosys.sh --auto"
+    p="pe.audio.sys/config/anacrontab"
     grep -Fvi "$p" $HOME/tmp/new_crontab > $HOME/tmp/tmp && mv $HOME/tmp/tmp $HOME/tmp/new_crontab
 
 

--- a/.install/update_peaudiosys.sh
+++ b/.install/update_peaudiosys.sh
@@ -227,7 +227,7 @@ python3 pe.audio.sys/share/www/scripts/drc2png.py 1>/dev/null 2>&1 &
 
 
 ########################################################################
-# Finally updates the updater script under ~/tmp/
+# Places the this updater script to be available under ~/tmp/
 ########################################################################
 cp "$ORIG"/.install/update_peaudiosys.sh "$HOME"/tmp/
 

--- a/pe.audio.sys/config/anacrontab
+++ b/pe.audio.sys/config/anacrontab
@@ -1,0 +1,5 @@
+# This anacrontab will be called daily from the user's crontab
+# if auto_update was configured
+
+# period delay  job-identifier  command
+1        1      auto_update     sh $HOME/tmp/download_peaudiosys.sh --auto; sh $HOME/tmp/update_peaudiosys.sh --auto

--- a/pe.audio.sys/config/anacrontab
+++ b/pe.audio.sys/config/anacrontab
@@ -1,5 +1,6 @@
 # This anacrontab will be called daily from the user's crontab
-# if auto_update was enabled
+# if auto_update was enabled. Anacron takes care of running the job
+# once at day when possible.
 
 # period delay  job-identifier  command
 1        1      auto_update     sh $HOME/tmp/download_peaudiosys.sh --auto; sh $HOME/tmp/update_peaudiosys.sh --auto

--- a/pe.audio.sys/config/anacrontab
+++ b/pe.audio.sys/config/anacrontab
@@ -1,5 +1,5 @@
 # This anacrontab will be called daily from the user's crontab
-# if auto_update was configured
+# if auto_update was enabled
 
 # period delay  job-identifier  command
 1        1      auto_update     sh $HOME/tmp/download_peaudiosys.sh --auto; sh $HOME/tmp/update_peaudiosys.sh --auto


### PR DESCRIPTION
the cronjob for auto_update now points to an user defined anacron table in order to ensure auto_update for non 24x7 machines