### PR TITLE
Usb dac watchdog

### DIFF
--- a/pe.audio.sys/config/config.yml.sample
+++ b/pe.audio.sys/config/config.yml.sample
@@ -1,7 +1,7 @@
 # ===================== ALSAMIXER VOLUME CONTROL (OPTIONAL) ====================
 
 # You need to investigate 'alsamixer' and 'amixer' command line tools
-#     'control':   the simple mixer control identifier that you want to use 
+#     'control':   the simple mixer control identifier that you want to use
 #     'limits':    the limit values as per shown by the 'amixer' tool (min, max)
 #     'zeros':     the values that defines your 0 dB settintg FOR EACH CHANNEL (list of values)
 #     'step_dB':   the fraction of dB corresponding to each value change
@@ -36,14 +36,14 @@ jack:
     # device:     guid:0x00130e01000406d2
     # period:     1024
     # nperiods:   3
-    # miscel:     
+    # miscel:
 
     # The most common "ALSA" backend (see your device name running aplay -l)
     backend:    alsa
     device:     hw:USB,0
     period:     1024
     nperiods:   2
-    miscel:     
+    miscel:
 
     # Additional cards to be used in jack by resampling,
     # either as capture or as playback devices.
@@ -216,9 +216,6 @@ source_monitors:
 
 plugins:
 
-    ## A watchdog for USB external DAC with standby mode
-    - usb_dac_watchdog.py
-
     ## Brutefir peak monitor (this should never occur, see plugin details)
     - peak_monitor.py
 
@@ -298,6 +295,9 @@ amp_off_stops_player: true
 
 # Amplifier switch off will turn off the computer:
 amp_off_shutdown: false
+
+# USB DAC watchdog (stop/start pe.audio.sys as per the USB DAC availability)
+usb_dac_watchdog: false
 
 # Control web page behavior
 web_config:

--- a/pe.audio.sys/config/config.yml.sample
+++ b/pe.audio.sys/config/config.yml.sample
@@ -296,7 +296,7 @@ amp_off_stops_player: true
 # Amplifier switch off will turn off the computer:
 amp_off_shutdown: false
 
-# USB DAC watchdog (stop/start pe.audio.sys as per the USB DAC availability)
+# A watchdog for an external USB DAC with standby mode to start/stop pe.audio.sys
 usb_dac_watchdog: false
 
 # Control web page behavior

--- a/pe.audio.sys/share/miscel/miscel.py
+++ b/pe.audio.sys/share/miscel/miscel.py
@@ -21,6 +21,52 @@ from    fmt         import Fmt
 
 # --- pe.audio.sys common usage functions:
 
+def detect_USB_DAC(cname):
+    """ Check if the provided card name is available,
+        and if it is USB type.
+    """
+    result = False
+    tmp = sp.check_output('aplay -l'.split()).decode().strip().split('\n')
+    for line in tmp:
+        if cname in line and 'USB' in line.upper():
+            result = True
+    return result
+
+
+def jackd_process(cname):
+    """ Check the if the jackd process is running
+    """
+    try:
+        tmp = sp.check_output('pgrep -fla jackd'.split()).decode().strip()
+    except:
+        tmp = ''
+    if cname in tmp:
+        return True
+    else:
+        return False
+
+
+def jackd_response(cname=''):
+    """ Check the jackd process responds properly
+        (!) A false jackd process may occur after the USB DAC
+            was disconnected
+    """
+    def check_jack_lsp():
+        try:
+            sp.check_output('jack_lsp')
+            return True
+        except:
+            return False
+
+    result = False
+
+    if jackd_process(cname):
+        if check_jack_lsp():
+            result = True
+
+    return result
+
+
 def process_is_running(pattern):
     """ check for a system process to be running by a given pattern
         (bool)

--- a/pe.audio.sys/share/plugins/usb_dac_watchdog.py
+++ b/pe.audio.sys/share/plugins/usb_dac_watchdog.py
@@ -13,96 +13,77 @@
 
     A false jackd process may occur after the USB DAC was disconnected.
 
+    Then, pe.audio.sys will be stopped.
+
     When the user does switch-on the USB DAC, then pe.audio.sys will restart.
 
-    Usage:      usb_dac_watchdog.py  start|stop
+    Usage:      usb_dac_watchdog.py  start
+
+    (i) This plugin is NOT intended to be configured under the
+        plugins section inside config.yml, PLEASE use a dedicated entry:
+
+            usb_dac_watchdog = true
 
 """
 import  subprocess as sp
 import  os
 import  sys
-from    time import sleep
+from    time     import sleep
+from    datetime import datetime
 
 UHOME = os.path.expanduser("~")
 sys.path.append(f'{UHOME}/pe.audio.sys/share/miscel')
 
-from config import CONFIG
+from miscel import  detect_USB_DAC, jackd_process, jackd_response, \
+                    CONFIG, LOG_FOLDER
 
-
-def detect_USB_DAC(cname):
-    """ Check if the provided card name is available,
-        and if it is USB type.
-    """
-    result = False
-    tmp = sp.check_output('aplay -l'.split()).decode().strip().split('\n')
-    for line in tmp:
-        if cname in line and 'USB' in line.upper():
-            result = True
-    return result
-
-
-def jackd_runs(cname=''):
-    """ Check the jackd process
-
-        (!) A false jackd process may occur after the USB DAC
-            was disconnected
-
-    """
-    def check_jack_lsp():
-        try:
-            sp.check_output('jack_lsp')
-            return True
-        except:
-            return False
-
-    result = False
-
-    try:
-        tmp = sp.check_output('pgrep -fla jackd'.split()).decode().strip()
-    except:
-        tmp = ''
-
-    if cname in tmp:
-        if check_jack_lsp():
-            result = True
-        else:
-            print('(usb_dac_watchdog.py) WARNING jackd process NOT RESPONDING')
-
-    return result
-
+CNAME   = CONFIG["jack"]["device"].split(':')[-1].split(',')[0]
+LOGPATH = f'{LOG_FOLDER}/usb_dac_watchdog.log'
 
 def peaudiosys_restart():
-    """ Restarts pe.audio.sys
-        (The script peaudiosys_restart.sh will waits for it to be running)
-    """
-    print('(usb_dac_watchdog.py) RESTARTING pe.audio.sys ... .. .')
-    sp.call(f'{UHOME}/bin/peaudiosys_restart.sh', shell=True)
+
+    now = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    with open(LOGPATH, 'w') as flog:
+        flog.write(f'{now} (usb_dac_watchdog.py) RESTARTING pe.audio.sys ... .. .\n')
+        flog.flush()
+        sp.call(f'{UHOME}/bin/peaudiosys_restart.sh', shell=True,
+                    stdout=flog, stderr=flog)
+
+
+def peaudiosys_stop():
+
+    now = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    with open(LOGPATH, 'w') as flog:
+        flog.write(f'{now} (usb_dac_watchdog.py) USB DAC \'{CNAME}\' NOT detected, stopping pe.audio.sys\n')
+        flog.write(f'{now} (usb_dac_watchdog.py) STOPPING pe.audio.sys ... .. .\n')
+        flog.flush()
+        sp.call(f'{UHOME}/bin/peaudiosys_restart.sh stop', shell=True,
+                    stdout=flog, stderr=flog)
 
 
 def start():
     """ MAIN LOOP
     """
-    card_name     = CONFIG["jack"]["device"].split(':')[-1].split(',')[0]
+    now = datetime.now().strftime("%Y%m%d_%H%M%S")
+    with open(LOGPATH, 'w') as flog:
+        flog.write(f'{now} (usb_dac_watchdog.py) WATCHDOG STARTED.\n')
+
 
     while True:
 
-        if detect_USB_DAC(card_name):
+        if detect_USB_DAC(CNAME):
 
-            if jackd_runs(card_name):
-                print(f'(usb_dac_watchdog.py) JACK is running with the card \'{card_name}\'')
-
-            else:
+            if not jackd_response(CNAME):
                 peaudiosys_restart()
 
         else:
-            print(f'(usb_dac_watchdog.py) USB DAC \'{card_name}\' NOT detected')
 
-        sleep(3)
+            if jackd_process(CNAME):
+                peaudiosys_stop()
 
-
-def stop():
-    cmd = 'pkill -f "usb_dac_watchdog.py start"'
-    sp.call(cmd, shell=True)
+        sleep(10)
 
 
 if __name__ == "__main__":
@@ -110,8 +91,6 @@ if __name__ == "__main__":
     if sys.argv[1:]:
         if sys.argv[1] == 'start':
             start()
-        elif sys.argv[1] == 'stop':
-            stop()
         else:
             print(__doc__)
     else:

--- a/pe.audio.sys/share/services/restart.py
+++ b/pe.audio.sys/share/services/restart.py
@@ -15,7 +15,7 @@ import  sys
 UHOME = os.path.expanduser("~")
 sys.path.append(f'{UHOME}/pe.audio.sys/share/miscel')
 
-from    config      import  LOG_FOLDER
+from    miscel      import  LOG_FOLDER, manage_amp_switch
 from    fmt         import  Fmt
 
 
@@ -38,6 +38,13 @@ def _peaudiosys_restart():
     return '(restart) restarting peaudiosys'
 
 
+def _amplifier_restart():
+    # This is an alternative when 'peaudiosys' service is down
+    print('restarting amplifier ... .. .')
+    manage_amp_switch('on')
+    return '(restart) restarting amplifier'
+
+
 # Interface function for this module
 def do( cmd ):
 
@@ -46,7 +53,9 @@ def do( cmd ):
     result = f'(restart) bad command \'{cmd}\''
 
     cmdmap = {  'server_restart':       _server_restart,
-                'peaudiosys_restart':   _peaudiosys_restart }
+                'peaudiosys_restart':   _peaudiosys_restart,
+                'amplifier_restart':   _amplifier_restart
+             }
 
 
     if cmd in cmdmap:

--- a/pe.audio.sys/share/www/js/main.js
+++ b/pe.audio.sys/share/www/js/main.js
@@ -1019,7 +1019,11 @@ function ck_peaudiosys_restart() {
 
 
 function omd_ampli_set(mode) {
-    control_cmd( 'aux amp_switch ' + mode );
+    const ans = control_cmd( 'aux amp_switch ' + mode );
+    if ( ! ans ) {
+        // Force to switch on the ampifier stuff (can include an USB DAC)
+        control_cmd( 'amplifier_restart' );
+    }
 }
 
 

--- a/pe.audio.sys/start.py
+++ b/pe.audio.sys/start.py
@@ -440,8 +440,11 @@ def run_plugins(mode='start'):
             sp.Popen(cmd, shell=True, stdout=sys.stdout, stderr=sys.stderr)
 
         elif mode == 'stop':
-            print(f'(start.py) stopping plugin: {plugin}', sp.check_output(cmd, shell=True).decode() )
-            sleep(.25)  # this is necessary because of asyncronous stopping
+            try:
+                ans = sp.check_output(cmd, shell=True).decode()
+            except Exception as e:
+                ans = str(e)
+            print(f'(start.py) stopping plugin: {plugin}', ans )
 
         else:
             pass


### PR DESCRIPTION
- Boton web ampli ON/OFF atendido por el servicio `restart` en caso de que el servicio `peaudiosys` esté parado.
- USB DAC watchdog como proceso opcional e independiente gestionado en start.py, NO configurado como plugin.